### PR TITLE
fix: restore linting of console statements

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,6 +96,7 @@ module.exports = {
     ],
     "prettier/prettier": "error",
     "sort-keys": "off",
+    "no-console": "error",
     "json/*": "error",
   },
 }

--- a/test/test.sh
+++ b/test/test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-bad_expected=6
+bad_expected=8
 good_expected=0
 
 bad_output=$(npx eslint --ignore-path .eslintignore.test --format json "test/bad/**/*")


### PR DESCRIPTION
`no-console` is not part of recommended rules, by removing our custom whitelisting we stopped linting for console statements