### PR TITLE
fix: error on no-explicit-any

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,6 +38,7 @@ module.exports = {
     },
   ],
   rules: {
+    "@typescript-eslint/no-explicit-any": "error",
     "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/no-unused-vars": [
       "error",

--- a/test/bad/ts/semicolons.ts
+++ b/test/bad/ts/semicolons.ts
@@ -1,1 +1,1 @@
-const yo = true;
+const yo: any = true


### PR DESCRIPTION
By default `no-explicit-any` rule only warns and no one cares about warnings