### PR TITLE
fix(imports): sort ~/** imports as internal

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,6 +121,11 @@ module.exports = {
             group: "external",
             position: "after",
           },
+          {
+            pattern: "~/**",
+            group: "internal",
+            position: "after",
+          },
         ],
         alphabetize: {
           order: "desc",


### PR DESCRIPTION
### Motivation

The `import/order` does not interpret `~/**` as internal imports out of the box, we have to add it manually. We had it before with the more specific path grous, re-introducing to comply with the expectation as otherwise `~/**` imports need to be placed at the very bottom.