### PR TITLE
fix: correct default entrpoint in export map

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "./prettier": "./pkg/prettier.js",
     "./next": "./pkg/next.js",
     "./react": "./pkg/react.js",
-    "./default": "./pkg/index.js"
+    ".": "./pkg/index.js"
   },
   "files": [
     "pkg/**/*"


### PR DESCRIPTION
builds in projects using the default entrypoint are failing - I only tested in a next project 😢 
https://github.com/carforyou/carforyou-whitelabel-widget-pkg/pull/69